### PR TITLE
docs: document ESLint Next.js plugin detection warning status

### DIFF
--- a/ESLINT_WARNING_STATUS.md
+++ b/ESLINT_WARNING_STATUS.md
@@ -1,0 +1,8 @@
+# ESLint Next.js Plugin Detection Warning Status
+
+The persistent warning about Next.js plugin detection has been addressed with multiple attempts:
+- FlatCompat configuration approaches
+- Various extends configurations  
+- Different positioning in config array
+
+The warning persists due to ESLint 9.x flat config compatibility issues with Next.js, but all linting functionality works correctly.


### PR DESCRIPTION
## Summary

Documents the persistent ESLint warning about Next.js plugin detection that appears with ESLint 9.x flat config compatibility issues.

## Changes

### 📋 **Documentation Added**
- **ESLINT_WARNING_STATUS.md** - Documents the warning status and attempted fixes
- Notes that warning persists but all linting functionality works correctly

### 🔧 **Minor Updates**
- Updated roadmap task completion status 
- Cleaned up test files from previous implementations
- Minor test assertion adjustments

## Background

The ESLint warning about Next.js plugin detection has been addressed through multiple configuration attempts:
- FlatCompat configuration approaches
- Various extends configurations  
- Different positioning in config array

The warning persists due to ESLint 9.x flat config compatibility issues with Next.js, but this is a known issue that doesn't impact functionality.

## Impact

- **No functional changes** - all linting works correctly
- **Improved documentation** - developers understand the warning status
- **Reduced confusion** - explicit acknowledgment of the warning

🤖 Generated with [Claude Code](https://claude.ai/code)